### PR TITLE
Show ale errors in status bar

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -83,7 +83,18 @@ Plug g:theme_plug
 call plug#end()
 
 " Theme
-let g:lightline = { 'colorscheme': g:theme_lightline }
+let g:lightline = {
+  \   'colorscheme': g:theme_lightline,
+  \   'active': {
+  \     'left': [
+  \       [ 'mode', 'paste' ],
+  \       [ 'readonly', 'filename', 'modified', 'ale' ]
+  \     ]
+  \   },
+  \   'component_function': {
+  \     'ale': 'ALEGetStatusLine'
+  \   }
+  \ }
 call SetTheme()
 " Shell
 call SetShell()
@@ -96,6 +107,7 @@ let g:elm_make_show_warnings = 1
 let g:fzf_layout = { 'window': 'enew' }
 let g:ale_sign_error = '✗'
 let g:ale_sign_warning = '!'
+let g:ale_statusline_format = ['✗ %d', '! %d', '✓']
 let test#strategy = "neoterm"
 
 " # Misc configuration


### PR DESCRIPTION
This adds the sum of the errors / warnings that ale reports in the status bar, or a checkmark if everything checks out.

We can easily move the indicator to a different position if we prefer that.