### PR TITLE
Set hdevtools as the default haskell linter

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -64,6 +64,7 @@ let g:ale_sign_warning = '!'
 let g:ale_statusline_format = ['✗ %d', '! %d', '✓']
 let g:elm_setup_keybindings = 0
 let test#strategy = "neoterm"
+let g:ale_linters = { 'haskell': ['hdevtools'] }
 
 " # Misc configuration
 hi Comment cterm=italic


### PR DESCRIPTION
Assuming you're working in Stack, I've found the hdevtool linter to be the only one that works properly (doesn't give you false positives for imports). It has as a disadvantage that you have to set up hdevtools. What do you think?