### PR TITLE
autoformat selected filetypes

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -145,10 +145,8 @@ augroup customCommands
   autocmd VimEnter *
   \ command! -bang -nargs=* Ag
   \ call fzf#vim#ag(<q-args>, '', { 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, <bang>0)
-augroup END
-augroup fmt
-  autocmd!
-  autocmd BufWritePre * Neoformat
+  autocmd BufWritePre *.elm Neoformat
+  autocmd BufWritePre *.hs Neoformat
 augroup END
 
 " # Commands

--- a/brangelina.vim
+++ b/brangelina.vim
@@ -147,6 +147,7 @@ augroup customCommands
   \ call fzf#vim#ag(<q-args>, '', { 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, <bang>0)
   autocmd BufWritePre *.elm Neoformat
   autocmd BufWritePre *.hs Neoformat
+  autocmd BufWritePre *.js Neoformat
 augroup END
 
 " # Commands


### PR DESCRIPTION
I found the on-default auto format often does the wrong thing. In languages I'm actively developing in, like Haskell and Elm I find it great. For other languages I'm mostly a guest in the codebase and in that case autoformat is disastrous. Is it the same for you at the moment? Also some languages have more of a culture for it than others.

This enables autoformatting by default only for these Elm and Haskell. I can imagine what works for me doesn't work for others, so it also makes sense to me to remove the default auto-formatting entirely and delegate that to personal .vimrc's.

Alternatively, it might be cool to be able to 'whitelist' projects, marking them as personal projects as opposed to other codebases.