### PR TITLE
preview in fzf

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -186,11 +186,11 @@ endfun
 command! -bang -nargs=* Rg
   \ call fzf#vim#grep(
   \   'rg --column --line-number --no-heading --color=always '.shellescape(<q-args>).'| tr -d "\017"', 1,
-  \   fzf#vim#with_preview({ 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' },'up:60%'),
+  \   fzf#vim#with_preview({ 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all,ctrl-q:toggle-preview' },'up:60%'),
   \   <bang>0)
 
 command! -bang -nargs=? -complete=dir Files
-  \ call fzf#vim#files(<q-args>, fzf#vim#with_preview({ 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, 'up:60%'), <bang>0)
+  \ call fzf#vim#files(<q-args>, fzf#vim#with_preview({ 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all,ctrl-q:toggle-preview' }, 'up:60%'), <bang>0)
 
 " # Plugins
 function! BrangelinaPlugins()

--- a/brangelina.vim
+++ b/brangelina.vim
@@ -182,10 +182,15 @@ function! CloseHiddenBuffers()
     endfor
     echon 'Deleted ' . l:tally . ' buffers'
 endfun
-" Support for a :Rg command (alternative for :Ag that uses ripgrep)
-command! -bang -nargs=* Rg
-  \ call fzf#vim#grep('rg --column --line-number --no-heading --color=always '.shellescape(<q-args>).'| tr -d "\017"', 1, { 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, <bang>0)
 
+command! -bang -nargs=* Rg
+  \ call fzf#vim#grep(
+  \   'rg --column --line-number --no-heading --color=always '.shellescape(<q-args>).'| tr -d "\017"', 1,
+  \   fzf#vim#with_preview({ 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' },'up:60%'),
+  \   <bang>0)
+
+command! -bang -nargs=? -complete=dir Files
+  \ call fzf#vim#files(<q-args>, fzf#vim#with_preview('up:60%'), <bang>0)
 
 " # Plugins
 function! BrangelinaPlugins()

--- a/brangelina.vim
+++ b/brangelina.vim
@@ -190,7 +190,7 @@ command! -bang -nargs=* Rg
   \   <bang>0)
 
 command! -bang -nargs=? -complete=dir Files
-  \ call fzf#vim#files(<q-args>, fzf#vim#with_preview('up:60%'), <bang>0)
+  \ call fzf#vim#files(<q-args>, fzf#vim#with_preview({ 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, 'up:60%'), <bang>0)
 
 " # Plugins
 function! BrangelinaPlugins()


### PR DESCRIPTION
this adds preview to `ctrl-p` and `Rg`. I prefer having the preview above, because I often have vim only on one side of the screen. maybe we can make that configurable. I also don't know how to get syntax highlighting.

<img width="698" alt="screen shot 2017-09-08 at 21 42 36" src="https://user-images.githubusercontent.com/1217681/30228571-aadf8642-94de-11e7-82b3-950ddb7a65f3.png">
<img width="977" alt="screen shot 2017-09-08 at 21 42 23" src="https://user-images.githubusercontent.com/1217681/30228572-aae3df80-94de-11e7-9134-d0b07d47afb8.png">
