### PR TITLE
Add highligthing of yanked area

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -212,6 +212,7 @@ function! BrangelinaPlugins()
   Plug 'junegunn/vader.vim'                  "  vim test framework
   Plug 'justinmk/vim-sneak'                  "  Medium-range motion
   Plug 'kassio/neoterm'                      "  Wrapper of some neovim's :terminal functions.
+  Plug 'machakann/vim-highlightedyank'
   Plug 'qpkorr/vim-bufkill'                  "  Kill a buffer without closing its window
   Plug 'sbdchd/neoformat'
   Plug 'sheerun/vim-polyglot'                "  Combines a whole bunch of vim syntax packs


### PR DESCRIPTION
I think this is nice. The idea is that when you combine yank with a movement, the area that was yanked is highlighted for a short period of time allowing you to confirm you grabbed what you wanted. It happens to me occasionally that I only find out my yank misfired when I pasted in another location, requiring me to go back. Appearantly Neovim added a hook for yank events to make this type of trick easy.