### PR TITLE
Allow project specific configurations

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -158,7 +158,7 @@ augroup customCommands
   autocmd VimEnter *
   \ command! -bang -nargs=* Ag
   \ call fzf#vim#ag(<q-args>, '', { 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, <bang>0)
-  autocmd BufWritePre * undojoin | Neoformat
+  autocmd BufWritePre * Neoformat
 augroup END
 
 " # Commands

--- a/brangelina.vim
+++ b/brangelina.vim
@@ -69,6 +69,7 @@ let g:haskell_indent_disable=1 "Automatic indenting and hindent don't agree
 let g:test#strategy = 'neoterm'
 let g:neoformat_enabled_haskell = ['hindent']
 let g:polyglot_disabled = ['haskell']
+let g:localvimrc_persistent=2 "See plugin: embear/vim-localvimrc
 
 " # Misc configuration
 hi Comment cterm=italic
@@ -205,6 +206,7 @@ function! BrangelinaPlugins()
   Plug 'editorconfig/editorconfig-vim'       "  Settings based on .editorconfig file
   Plug 'elentok/todo.vim'                    "  Todo.txt support
   Plug 'elmcast/elm-vim'                     "  Elm language syntac
+  Plug 'embear/vim-localvimrc'               "  Support project-specific vim configurations
   Plug 'godlygeek/tabular'                   "  align stuff
   Plug 'haya14busa/incsearch.vim'            "  Improved incremental searching
   Plug 'idris-hackers/idris-vim'             "  Idris mode

--- a/brangelina.vim
+++ b/brangelina.vim
@@ -67,7 +67,6 @@ let g:elm_setup_keybindings = 0
 let g:ale_linters = { 'haskell': ['hlint', 'hdevtools'] }
 let g:haskell_indent_disable=1 "Automatic indenting and hindent don't agree
 let g:test#strategy = 'neoterm'
-let g:neoformat_enabled_haskell = ['hindent']
 let g:polyglot_disabled = ['haskell']
 let g:localvimrc_persistent=2 "See plugin: embear/vim-localvimrc
 
@@ -159,9 +158,7 @@ augroup customCommands
   autocmd VimEnter *
   \ command! -bang -nargs=* Ag
   \ call fzf#vim#ag(<q-args>, '', { 'options': '--bind ctrl-a:select-all,ctrl-d:deselect-all' }, <bang>0)
-  autocmd BufWritePre *.elm Neoformat
-  autocmd BufWritePre *.hs Neoformat
-  autocmd BufWritePre *.js Neoformat
+  autocmd BufWritePre * undojoin | Neoformat
 augroup END
 
 " # Commands


### PR DESCRIPTION
This pr adds the [embear/vim-localvimrc](https://github.com/embear/vim-localvimrc) plugin to allow project-specific configuration. Upon loading a file it looks for .lvimrc files in a parent directory of that file. If one is found it is loaded in addition to the regular .vimrc. As a security precaution, the first time you source a particular '.lvimrc' file you need to give permission.

The motivation for this change were some issues I was having this week getting the right settings for neoformat for a couple of different projects. I accidentally reformatted a number of files in a Haskell project that was not using hindent resulting in large diff for a PR. I had to go into brangelina to overwrite formatting settings for a while. Later I forgot to remove the custom configurations again and pushed a PR containing code that should have been run through hindent and wasn't.

These workflows are much nicer using this plugin. In this PR neoformat is enabled by default, but if we want to restrict the linters ran for a particular project, we can just do that by throwing a .lvimrc into the root of that project with the relevant configuration.