### PR TITLE
Update gitgutter signs sooner

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -15,6 +15,7 @@ set noswapfile
 set number
 set path=**
 set shell=/bin/bash " required by gitgutter plugin
+set updatetime=100  " ensures gitgutter updates every 100ms
 set shiftround
 set shiftwidth=2
 set splitbelow


### PR DESCRIPTION
The git addition / update / removal symbols in the margin of the editor tend to update slowly (I think after 4 seconds by default). This bumps it to a 100ms.