### PR TITLE
update nvim-completion-manager to ncm2

### DIFF
--- a/brangelina.vim
+++ b/brangelina.vim
@@ -141,7 +141,7 @@ command! -bang -nargs=? -complete=dir Files
 
 " # Plugins
 function! BrangelinaPlugins()
-  Plug 'roxma/nvim-completion-manager'
+  Plug 'ncm2/ncm2'
   if !has('nvim')
     Plug 'roxma/vim-hug-neovim-rpc'
   endif


### PR DESCRIPTION
According to https://github.com/roxma/nvim-completion-manager, this package has been deprecated and should be updated to ncm2. Sourcing nvim-completion-manager results in sad errors!