### PR TITLE
update init.example.vim to set lightline correctly

### DIFF
--- a/init.example.vim
+++ b/init.example.vim
@@ -13,7 +13,7 @@ call plug#end()
 
 " (4) Configure the theme you want to use below.
 colorscheme NeoSolarized
-let g:lightline.colorscheme = 'solarized'
+let g:lightline = { 'colorscheme': 'solarized' }
 set background=dark
 let g:neoterm_shell = 'zsh'
 


### PR DESCRIPTION
Changes how lightline is set in init.example.vim. Otherwise you end up with the error: `Undefined variable: g:lightline`