### PR TITLE
Make clipboard cross-platform

### DIFF
--- a/whimsical.vim
+++ b/whimsical.vim
@@ -4,7 +4,7 @@ syntax on
 
 :scriptencoding utf-8
 let &showbreak = '↪ '
-set clipboard=unnamed
+set clipboard^=unnamed,unnamedplus
 set completefunc=emoji#complete
 set completeopt+=longest
 set completeopt-=preview


### PR DESCRIPTION
On Linux, we need a slightly different clipboard value to have proper yanking.

Taken from here:
https://stackoverflow.com/a/30691754