### PR TITLE
Remove nonexistent options from vim installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Whimsical.vim
 
 ## Installation instructions
-- install vim8 with python3 support
-    `brew install vim --without-python --with-python3`
+- install vim8
+    `brew install vim`
 - [Install Neovim, along with the Python2, Python3, and Ruby modules](https://github.com/neovim/neovim/wiki/Installing-Neovim)
 - Run `:CheckHealth` to ensure everything is working correctly
 - [Install vim-plug](https://github.com/junegunn/vim-plug#installation)


### PR DESCRIPTION
Python 3 is apparently now the default!